### PR TITLE
Fix make_plot() error when called with a subset of models

### DIFF
--- a/balaban/balaban.py
+++ b/balaban/balaban.py
@@ -70,9 +70,10 @@ class bosko:
         mins_played = np.array(self.df['Minutes'])
 
         if model_names is not None:
-            which_mods = np.array([np.min(np.where(self.labels == name)[0]) for name in model_names])
-            models = self.models[which_mods]
-            labels = self.labels[which_mods]
+            which_mods = [self.labels.index(m_name) for m_name in model_names]
+            models = [self.models[i] for i in which_mods]
+            labels = [self.labels[i] for i in which_mods]
+
         else:
             models = self.models
             labels = self.labels


### PR DESCRIPTION
### Issue
`self.models` and `self.labels` are initialised as lists:
https://github.com/anenglishgoat/balaban/blob/7e86c57efa90ff8544c76240df6e67c9d8481a26/balaban/balaban.py#L13-L14

But later in `make_plot()`, numpy element-wise comparison and np slicing syntax is used:
https://github.com/anenglishgoat/balaban/blob/7e86c57efa90ff8544c76240df6e67c9d8481a26/balaban/balaban.py#L72-L75

Which gives the error: 
```
ValueError: zero-size array to reduction operation minimum which has no identity
```

<br>

### Solution
Replaced lines 73-75 with python list operations