### PR TITLE
Handle edge case when player has a missing stat

### DIFF
--- a/balaban/utils.py
+++ b/balaban/utils.py
@@ -193,10 +193,14 @@ def estimate_model(a, b, model_type):
 def obtain_player_quantiles(model, player_index):
     model_type = model[3]
     import numpy as np
+    
+    pind = np.arange(np.shape(model[2])[0])[model[2]]
+    pind = np.where(pind == player_index)[0]
+    if pind.shape[0] == 0: 
+        return (np.zeros(25), np.linspace(0,1,26)), np.zeros(3)
+
     if model_type == 'count':
         from scipy.stats import gamma
-        pind = np.arange(np.shape(model[2])[0])[model[2]]
-        pind = np.where(pind == player_index)[0]
         percentile_hist = np.histogram(
             gamma.cdf(model[0][:, pind],
                       a=np.mean(model[1][:, 1]) * np.mean(model[1][:, 0]),
@@ -205,8 +209,6 @@ def obtain_player_quantiles(model, player_index):
         per90_quantiles = np.quantile(model[0][:, pind], [0.125, 0.5, 0.875])
     elif model_type == 'success':
         from scipy.stats import beta
-        pind = np.arange(np.shape(model[2])[0])[model[2]]
-        pind = np.where(pind == player_index)[0]
         percentile_hist = np.histogram(
             beta.cdf(model[0][:, pind] / 100,
                      a=np.mean(model[1][:, 0]),
@@ -215,8 +217,6 @@ def obtain_player_quantiles(model, player_index):
         per90_quantiles = np.quantile(model[0][:, pind], [0.05, 0.5, 0.95])
     elif model_type == 'expected':
         from scipy.stats import beta
-        pind = np.arange(np.shape(model[2])[0])[model[2]]
-        pind = np.where(pind == player_index)[0]
         percentile_hist = np.histogram(
             beta.cdf(model[0][:, pind],
                      a=np.mean(model[1][:, 2]) * np.mean(model[1][:, 0]),
@@ -224,8 +224,6 @@ def obtain_player_quantiles(model, player_index):
             bins=25)
         per90_quantiles = np.quantile(model[0][:, pind], [0.05, 0.5, 0.95])
     elif (model_type == 'expected_per90') | (model_type == 'adj_pass'):
-        pind = np.arange(np.shape(model[2])[0])[model[2]]
-        pind = np.where(pind == player_index)[0]
         samps_flat = np.random.choice(model[0].flatten(), size=5000)  ## downsample to make cdf quicker to compute
         sorted_samps = np.sort(samps_flat)
         ecdf = lambda x: np.sum(sorted_samps[:, None] < x, axis=0) / len(sorted_samps)


### PR DESCRIPTION
### Issue:
If a player has a missing stat, then `obtain_player_quantiles()` during model building fails with a cryptic error like this:
```
ValueError: operands could not be broadcast together with shapes (5000,1) (0,6000) 
```

### Solution:
Return all zeros if this occurs, meaning: 

- No green bars on the plot
- Average, 10th and 90th percentiles are all zero

Not sure if this is the perfect solution, maybe it could also make sense to return the population statistics if we consider it our prior? Open to suggestions.

For now, here's what this'd look like on a plot (player has zero attempted dribbles):
<br>
![Screenshot 2020-12-04 at 02 25 13](https://user-images.githubusercontent.com/20226561/101114216-eff5bf00-35d8-11eb-92be-689c1a438124.png)
